### PR TITLE
Feature/schedule delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,6 +2507,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -4657,11 +4658,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ log = "0.4.29"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2.4"
+uuid = "1.23.0"

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Whether you're looking for where to find fries today (`!oslf`) or want to subscr
 
 - `!schedule <SubCommand> [OPTIONS]`
 > Schedule a command with `create` Sub command or list all task of your room with `-l, --list` Sub command.
-> Only create Sub command has some options :
+> Create Sub command has some options :
 > `-j | --job` for specify the command to execute
 > `-h | --hour` for specify the hour when the command will be executed (by default 11:30)
 > `-d | --day` for specify the day when the command will be executed (by default mon-fri)
+> Delete a cron with `delete` Sub command, you need to specify the name of the task with `-n, --name` flag.
 
 - `!oslf`
 > Returns all menus that contain fries.

--- a/src/services/schedule.rs
+++ b/src/services/schedule.rs
@@ -218,7 +218,7 @@ impl ScheduleClient {
                 .split_whitespace()
                 .nth(5)
                 .unwrap_or("Undefined");
-            let _ = writeln!(message, " - name : **{}** \n task : `{}` \n day(s) : {} \n hour : {} \n id : {} \n", cron.name, cron.command, days, cron.hour, cron.job_id);
+            let _ = writeln!(message, " - name : **{}** \n task : `{}` \n day(s) : {} \n hour : {} \n", cron.name, cron.command, days, cron.hour);
         }
         message
     }
@@ -244,7 +244,7 @@ OPTIONS FOR 'create':
     -h, --hour <HOUR>   Specify the hour to execute the command, 11:30 by default.
 
 OPTIONS FOR 'delete':
-    -n, --name <NAME>   Specify the name of the cron you want delete.
+    -n, --name <NAME>   Specify the name of the cron you want to remove.
 
 DAY PATTERNS:
     You can use cron-style formatting for the <DAYS> parameter:

--- a/src/services/schedule.rs
+++ b/src/services/schedule.rs
@@ -152,6 +152,58 @@ impl ScheduleClient {
         }
     }
 
+    async fn delete_cron(args: &str, room_id: &str, state: &Arc<AppState>) -> String {
+        let mut task: Option<String> = None;
+        let mut iter = args.split_whitespace().peekable();
+
+        while let Some(word) = iter.next() {
+            match word {
+                "-n" | "--name" => {
+                    let mut name_parts = Vec::new();
+                    while let Some(&_next_word) = iter.peek() {
+                        name_parts.push(iter.next().unwrap());
+                    }
+                    if !name_parts.is_empty() {
+                        task = Some(name_parts.join(" "));
+                    }
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+        let Some(name) = task else {
+            return "Failed to delete cron, please specify the name of the task. Example: `!schedule delete -n task_name`".to_string();
+        };
+
+        let room_crons = DbCron::get_by_room_id(&state.db, room_id).await;
+        let cron_to_delete = room_crons.into_iter().find(|c| c.name == name);
+
+        let Some(cron) = cron_to_delete else {
+            return format!("Error : Unknown task '{}'.", name);
+        };
+
+        if let Ok(uuid) = uuid::Uuid::parse_str(&cron.job_id) {
+            if let Err(e) = state.scheduler.remove(&uuid).await {
+                log::error!("Failed to remove task : {} from room : {}, {}", &name, &room_id, e);
+                return "Failed to remove task, please try again".to_string();
+            } else {
+                log::info!("Task {} remove successfully", uuid);
+            }
+        } else {
+            log::error!("Invalide Id in db : {}", cron.job_id);
+            return "Failed to remove task, please try again".to_string();
+        }
+
+        let db_selected = DbCron::delete_cron(&state.db, room_id, &name).await;
+        if db_selected {
+            format!("Task : `{}` has been removed successfully", name)
+        } else {
+            "Failed to remove task, please try again".to_string()
+        }
+
+    }
+
     async fn list_room_crons(room_id: &str, state: &Arc<AppState>) -> String {
         let room_crons = DbCron::get_by_room_id(&state.db, room_id).await;
 
@@ -166,7 +218,7 @@ impl ScheduleClient {
                 .split_whitespace()
                 .nth(5)
                 .unwrap_or("Undefined");
-            let _ = writeln!(message, " - **{}** | `{}` | {} | {}", cron.name, cron.command, days, cron.hour);
+            let _ = writeln!(message, " - name : **{}** \n task : `{}` \n day(s) : {} \n hour : {} \n id : {} \n", cron.name, cron.command, days, cron.hour, cron.job_id);
         }
         message
     }
@@ -182,6 +234,7 @@ USAGE:
 
 SUBCOMMANDS:
     create              Create a new scheduled task.
+    delete              Delete a scheduled task.
     -l, --list          List all scheduled tasks in the current room.
     --help              Print this help message.
 
@@ -189,6 +242,9 @@ OPTIONS FOR 'create':
     -d, --date <DAYS>   Specify the day(s) to execute the command, mon-fri by default.
     -j, --job <CMD>     The exact bot command to run.
     -h, --hour <HOUR>   Specify the hour to execute the command, 11:30 by default.
+
+OPTIONS FOR 'delete':
+    -n, --name <NAME>   Specify the name of the cron you want delete.
 
 DAY PATTERNS:
     You can use cron-style formatting for the <DAYS> parameter:
@@ -218,6 +274,14 @@ EXAMPLES:
                 let remaining_args = args.trim_start_matches("create").trim();
                 if !remaining_args.is_empty() {
                     Self::controller_create_cron(remaining_args, room_id, state).await
+                } else {
+                    Self::schedule_help().to_string()
+                }
+            }
+            Some("delete") => {
+                let remaining_args = args.trim_start_matches("delete").trim();
+                if !remaining_args.is_empty() {
+                    Self::delete_cron(remaining_args, room_id, state).await
                 } else {
                     Self::schedule_help().to_string()
                 }


### PR DESCRIPTION
This pull request adds the ability to delete scheduled tasks (crons) by name, improves the formatting of the cron listing, and updates the help documentation to reflect the new functionality.

**New Feature: Task Deletion**
* Added a `delete_cron` method to allow users to delete scheduled tasks by specifying their name. This includes error handling for missing or unknown task names and ensures removal from both the scheduler and the database.
* Updated the command handler to support a `delete` subcommand, parsing arguments and invoking the new deletion logic.

**Documentation and Help Updates**
* Added `delete` to the list of available subcommands in the help message, and documented the `-n/--name` option for specifying the task to remove. [[1]](diffhunk://#diff-86661c94752c74e8a5d002504e60f9cf7f383eecbdb56c3218e53b8db4df2323R237) [[2]](diffhunk://#diff-86661c94752c74e8a5d002504e60f9cf7f383eecbdb56c3218e53b8db4df2323R246-R248)

**Formatting Improvements**
* Improved the output format of the cron listing to make task details clearer and easier to read.

**Dependency Management**
* Added the `uuid` crate to `Cargo.toml` to support handling of task IDs.